### PR TITLE
Fix field access segment whitespace issue

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -336,7 +336,7 @@ module.exports = grammar({
       prec.left(
         seq(
           alias($._dot_without_leading_whitespace, $.dot),
-          $.lower_case_identifier
+          $._lower_case_identifier_without_leading_whitespace
         )
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -336,7 +336,10 @@ module.exports = grammar({
       prec.left(
         seq(
           alias($._dot_without_leading_whitespace, $.dot),
-          $._lower_case_identifier_without_leading_whitespace
+          alias(
+            $._lower_case_identifier_without_leading_whitespace,
+            $.lower_case_identifier
+          )
         )
       ),
 


### PR DESCRIPTION
Fix field access segment so that there cannot be whitespace between the dot and the identifier.

I'm not sure if this is the correct change or if there are other places that need updated, but it seems to be what we want for https://github.com/elm-tooling/elm-language-server/pull/251.