### PR TITLE
add complex comment test case

### DIFF
--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -14,7 +14,7 @@ One line comments
 -- MODEL
 -- update
 -- more words
--- (isOkay x || any isOkay xs) would not get TCO
+-- note: (isOkay x || any isOkay xs) would not get TCO
 
 ---
 

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -14,7 +14,7 @@ One line comments
 -- MODEL
 -- update
 -- more words
--- note: (isOkay x || any isOkay xs) would not get TCO
+-- (isOkay x || any isOkay xs) would not get TCO
 
 ---
 
@@ -63,4 +63,81 @@ comments like in Elm.
 
 (file
   (block_comment)
+)
+
+=====================================
+Comment syntax within a string
+=====================================
+
+module Main exposing ( ..)
+one="\"{-"
+two="""-}
+notAThing = something
+\"""
+notAThing2 = something
+"""
+three = '"' {- "
+notAThing3 = something
+-}
+four{--}=--{-
+    1
+five = something
+--}
+
+---
+(file
+  (module_declaration
+    (module)
+    (upper_case_qid (upper_case_identifier))
+    (exposing_list
+      (exposing)
+      (left_parenthesis)
+      (double_dot)
+      (right_parenthesis)
+    )
+  )
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (string_constant_expr
+      (open_quote)
+      (string_escape)
+      (regular_string_part)
+      (close_quote)
+    )
+  )
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (string_constant_expr
+      (open_quote)
+      (regular_string_part)
+      (string_escape)
+      (regular_string_part)
+      (regular_string_part)
+      (close_quote)
+    )
+  )
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (char_constant_expr
+      (open_char)
+      (regular_string_part)
+      (close_char)
+    )
+  )
+  (block_comment)
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (block_comment)
+    (eq)
+    (line_comment)
+    (number_constant_expr (number_literal))
+  )
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (value_expr (value_qid (lower_case_identifier))))
+  (line_comment)
 )


### PR DESCRIPTION
An extra test cannot hurt. Credit for the testcase goes to @lydell. I originally added the test case because I thought it failed, turned out that the `/` were double escaped and once I fix that the test passed.