### PR TITLE
Comment out scanner.c inclusion in binding.go

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,9 +2,9 @@ package tree_sitter_elm
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
-#if __has_include("../../src/scanner.c")
-#include "../../src/scanner.c"
-#endif
+// #if __has_include("../../src/scanner.c")
+// #include "../../src/scanner.c"
+// #endif
 import "C"
 
 import "unsafe"


### PR DESCRIPTION
Comment out the inclusion of scanner.c in binding.go.